### PR TITLE
Fixed handle_int and handle_long

### DIFF
--- a/afsapi/__init__.py
+++ b/afsapi/__init__.py
@@ -162,7 +162,7 @@ class AFSAPI():
         if doc is None:
             return None
 
-        return int(doc.value.u8.text) or None
+        return int(doc.value.u8.text)
 
     # returns an int, assuming the value does not exceed 8 bits
     @asyncio.coroutine
@@ -172,7 +172,7 @@ class AFSAPI():
         if doc is None:
             return None
 
-        return int(doc.value.u32.text) or None
+        return int(doc.value.u32.text)
 
     @asyncio.coroutine
     def handle_list(self, item):


### PR DESCRIPTION
When the API returned zero these functions would return None, this caused it to fail to look-up the current mode in the mode list if the mode was 0 (as it was looking for None rather than 0). It may have caused other issues too.