### PR TITLE
fix get_eq_preset(): 0 is a valid EQ preset

### DIFF
--- a/afsapi/api.py
+++ b/afsapi/api.py
@@ -521,7 +521,7 @@ class AFSAPI:
     # EQ Presets
     async def get_eq_preset(self) -> t.Optional[Equaliser]:
         v = await self.handle_int(API["eqpreset"])
-        if not v:
+        if v is None:
             return None
 
         for eq in await self.get_equalisers():


### PR DESCRIPTION
Fix the condition to explicitly check for None instead of checking for
falsy values (v can be 0, which is a falsy value in Python)

Resolves: https://github.com/home-assistant/core/issues/69812
Resolves: https://github.com/home-assistant/core/issues/74949