### PR TITLE
do not set sid parameter in a CREATE_SESSION call

### DIFF
--- a/afsapi/api.py
+++ b/afsapi/api.py
@@ -161,6 +161,7 @@ class AFSAPI:
 
     # http request helpers
     async def _create_session(self) -> t.Optional[str]:
+        self.sid = None
         return unpack_xml(
             await self.__call("CREATE_SESSION", retry_with_session=False), "sessionId"
         )


### PR DESCRIPTION
If `__call()` is called with `force_new_session=True`, it will call
`self._create_session()`, which will in turn call `__call()` again and add
the current `self.sid` to its params dict.

This commit changes this behavior to not add the previous session id when
requesting a new session id.

Btw, thanks a lot for maintaining this library! :)