### PR TITLE
Expose network interface information

### DIFF
--- a/afsapi/__init__.py
+++ b/afsapi/__init__.py
@@ -1,6 +1,13 @@
 from .api import AFSAPI  # noqa
-from .models import *  # noqa
-from .exceptions import *  # noqa
+from afsapi.exceptions import (
+    FSApiException,
+    InvalidPinException,
+    InvalidSessionException,
+    NotImplementedException,
+    OutOfRangeException,
+    ConnectionError,
+)
+from afsapi.models import Preset, Equaliser, PlayerMode, PlayControl, PlayState
 
 from importlib.metadata import version, PackageNotFoundError
 

--- a/afsapi/__init__.py
+++ b/afsapi/__init__.py
@@ -16,3 +16,8 @@ except PackageNotFoundError:  # pragma: no cover
             "use the PyPI ones."
         )
 __version__ = VERSION
+
+__all__ = ['AFSAPI', 'PlayState', 'PlayControl', 'PlayerMode', 'Equaliser',
+           'Preset', 'FSApiException', 'NotImplementedException',
+           'ConnectionError', 'OutOfRangeException', 'InvalidPinException',
+           'InvalidSessionException']

--- a/afsapi/api.py
+++ b/afsapi/api.py
@@ -53,6 +53,7 @@ API = {
     "wired_active": "netRemote.sys.net.wired.interfaceEnable",
     "wlan_mac": "netRemote.sys.net.wlan.macAddress",
     "wlan_active": "netRemote.sys.net.wlan.interfaceEnable",
+    "rssi": "netRemote.sys.net.wlan.rssi",
     # sys.info
     "friendly_name": "netRemote.sys.info.friendlyName",
     "radio_id": "netRemote.sys.info.radioId",
@@ -367,6 +368,19 @@ class AFSAPI:
             return await self.handle_text(API["wlan_mac"])
         else:
             return await self.handle_text(API["wired_mac"])
+
+    async def get_rssi(self) -> t.Optional[int]:
+        """Get the current wlan Received Signal Strength Indication in dBm"""
+
+        # RSSI is returned as a percentage by the API, scaled linearly between
+        # -80dBm (0%) and -20dBm (100%).  100% indicates a wired
+        # connection.  This functions returns the dBm value of RSSI.
+
+        rssi = await self.handle_int(API["rssi"])
+        if rssi is not None:
+            return int(round(rssi * 0.6 - 80))
+        else:
+            return None
 
     async def get_power(self) -> t.Optional[bool]:
         """Check if the device is on."""

--- a/afsapi/api.py
+++ b/afsapi/api.py
@@ -49,6 +49,10 @@ API = {
     # sys
     "power": "netRemote.sys.power",
     "mode": "netRemote.sys.mode",
+    "wired_mac": "netRemote.sys.net.wired.macAddress",
+    "wired_active": "netRemote.sys.net.wired.interfaceEnable",
+    "wlan_mac": "netRemote.sys.net.wlan.macAddress",
+    "wlan_active": "netRemote.sys.net.wlan.interfaceEnable",
     # sys.info
     "friendly_name": "netRemote.sys.info.friendlyName",
     "radio_id": "netRemote.sys.info.radioId",
@@ -355,6 +359,14 @@ class AFSAPI:
     async def get_radio_id(self) -> t.Optional[str]:
         """Get the friendly name of the device."""
         return await self.handle_text(API["radio_id"])
+
+    async def get_mac(self) -> t.Optional[str]:
+        """Get the MAC address of the device."""
+        on_wlan = await self.handle_int(API["wlan_active"])
+        if bool(on_wlan):
+            return await self.handle_text(API["wlan_mac"])
+        else:
+            return await self.handle_text(API["wired_mac"])
 
     async def get_power(self) -> t.Optional[bool]:
         """Check if the device is on."""

--- a/afsapi/api.py
+++ b/afsapi/api.py
@@ -635,7 +635,7 @@ class AFSAPI:
         """Check when and if the device is going to sleep."""
         return await self.handle_long(API["sleep"])
 
-    async def set_sleep(self, value: bool = False) -> t.Optional[bool]:
+    async def set_sleep(self, value: int = 0) -> t.Optional[bool]:
         """Set device sleep timer."""
         return await self.handle_set(API["sleep"], int(value))
 

--- a/async_tests.py
+++ b/async_tests.py
@@ -84,6 +84,7 @@ async def test_info():
         print(f"Radio ID: {await afsapi.get_radio_id()}")
         print(f"Version: {await afsapi.get_version()}")
         print(f"MAC: {await afsapi.get_mac()}")
+        print(f"RSSI: {await afsapi.get_rssi()} dBm")
 
         name = await afsapi.get_play_name()
         print("Name: %s" % name)

--- a/async_tests.py
+++ b/async_tests.py
@@ -83,6 +83,7 @@ async def test_info():
 
         print(f"Radio ID: {await afsapi.get_radio_id()}")
         print(f"Version: {await afsapi.get_version()}")
+        print(f"MAC: {await afsapi.get_mac()}")
 
         name = await afsapi.get_play_name()
         print("Name: %s" % name)

--- a/async_tests.py
+++ b/async_tests.py
@@ -10,7 +10,7 @@ PIN = 1234
 TIMEOUT = 2  # in seconds
 
 
-async def test_sys():
+async def test_sys() -> None:
     """Test sys functions."""
     try:
         afsapi = await AFSAPI.create(URL, PIN, TIMEOUT)
@@ -38,7 +38,7 @@ async def test_sys():
         logging.error(traceback.format_exc())
 
 
-async def test_volume():
+async def test_volume() -> None:
     """Test volume functions."""
     try:
         afsapi = await AFSAPI.create(URL, PIN, TIMEOUT)
@@ -70,7 +70,7 @@ async def test_volume():
         logging.error(traceback.format_exc())
 
 
-async def test_info():
+async def test_info() -> None:
     """Test info functions."""
     try:
         afsapi = await AFSAPI.create(URL, PIN, TIMEOUT)
@@ -113,7 +113,7 @@ async def test_info():
         logging.error(traceback.format_exc())
 
 
-async def test_play():
+async def test_play() -> None:
     """Test play functions."""
     try:
         afsapi = await AFSAPI.create(URL, PIN, TIMEOUT)


### PR DESCRIPTION
This PR adds two new API methods to allow information about the radio's current network interface to be fetched.

`get_mac()` returns the MAC address of the active network interface (wired or wlan).
`get_rssi()` returns the signal strength reported by the interface.

Adding these methods should support better diagnostics when adding a Frontier Silicon radio into a home automation system.

The PR also makes several tweaks to type annotations in the code, to fix MyPy errors revealed when testing `asynch_tests.py`.  These shouldn't have any runtime impact, but could affect code that uses some of the internals of the API via `from afsapi import *`, rather than using the attributes listed in `__all__`.