### PR TITLE
Fixed Playing and Pausing when in mode internet radio

### DIFF
--- a/afsapi/api.py
+++ b/afsapi/api.py
@@ -517,6 +517,10 @@ class AFSAPI:
         """
         return await self.handle_set(API["control"], int(value))
 
+    async def stop(self) -> t.Optional[bool]:
+        """Stop (and Start) media."""
+        return await self.play_control(PlayControl.STOP)
+    
     async def play(self) -> t.Optional[bool]:
         """Play media."""
         return await self.play_control(PlayControl.PLAY)

--- a/afsapi/api.py
+++ b/afsapi/api.py
@@ -519,30 +519,18 @@ class AFSAPI:
 
     async def play(self) -> t.Optional[bool]:
         """Play media."""
-        mode = await self.get_mode()
-        if mode.label == "Internet radio":
-            return await self.play_control(PlayControl.STOP)
         return await self.play_control(PlayControl.PLAY)
 
     async def pause(self) -> t.Optional[bool]:
         """Pause playing."""
-        mode = await self.get_mode()
-        if mode.label == "Internet radio":
-            return await self.play_control(PlayControl.STOP)
         return await self.play_control(PlayControl.PAUSE)
 
     async def forward(self) -> t.Optional[bool]:
         """Next media."""
-        mode = await self.get_mode()
-        if mode.label == "Internet radio":
-            return None #Not supported
         return await self.play_control(PlayControl.NEXT)
 
     async def rewind(self) -> t.Optional[bool]:
         """Previous media."""
-        mode = await self.get_mode()
-        if mode.label == "Internet radio":
-            return None #Not supported
         return await self.play_control(PlayControl.PREV)
 
     async def get_equalisers(self) -> t.List[Equaliser]:

--- a/afsapi/api.py
+++ b/afsapi/api.py
@@ -519,18 +519,30 @@ class AFSAPI:
 
     async def play(self) -> t.Optional[bool]:
         """Play media."""
+        mode = await self.get_mode()
+        if mode.label == "Internet radio":
+            return await self.play_control(PlayControl.STOP)
         return await self.play_control(PlayControl.PLAY)
 
     async def pause(self) -> t.Optional[bool]:
         """Pause playing."""
+        mode = await self.get_mode()
+        if mode.label == "Internet radio":
+            return await self.play_control(PlayControl.STOP)
         return await self.play_control(PlayControl.PAUSE)
 
     async def forward(self) -> t.Optional[bool]:
         """Next media."""
+        mode = await self.get_mode()
+        if mode.label == "Internet radio":
+            return None #Not supported
         return await self.play_control(PlayControl.NEXT)
 
     async def rewind(self) -> t.Optional[bool]:
         """Previous media."""
+        mode = await self.get_mode()
+        if mode.label == "Internet radio":
+            return None #Not supported
         return await self.play_control(PlayControl.PREV)
 
     async def get_equalisers(self) -> t.List[Equaliser]:

--- a/afsapi/models.py
+++ b/afsapi/models.py
@@ -11,6 +11,7 @@ class PlayState(IntEnum):
 
 
 class PlayControl(IntEnum):
+    STOP = 0
     PLAY = 1
     PAUSE = 2
     NEXT = 3

--- a/async_tests.py
+++ b/async_tests.py
@@ -121,20 +121,27 @@ async def test_play() -> None:
         status = await afsapi.get_play_status()
         print("Status: %s" % status)
 
+        pause = await afsapi.pause()
+        print("Start play succeeded? - %s" % pause)
+        await asyncio.sleep(2)
+
         start_play = await afsapi.play()
         print("Start play succeeded? - %s" % start_play)
-        await asyncio.sleep(1)
+        await asyncio.sleep(2)
 
         forward = await afsapi.forward()
         print("Next succeeded? - %s" % forward)
-        await asyncio.sleep(1)
+        await asyncio.sleep(2)
 
         rewind = await afsapi.rewind()
         print("Prev succeeded? - %s" % rewind)
 
+        stop = await afsapi.stop()
+        print("Stop play succeeded? - %s" % stop)
+        await asyncio.sleep(2)
+
     except Exception:
         logging.error(traceback.format_exc())
-
 
 loop = asyncio.new_event_loop()
 


### PR DESCRIPTION
When in mode Internet Radio, playing and stopping a stream is achieved running `http://<IP>/fsapi/SET/netRemote.play.control?pin=1234&value=0`, whereas in other modes value is 1 for Play and 2 for Pause.

This pull request checks which mode the radio is in, and send 0 (aka STOP) when in Internet radio mode.